### PR TITLE
feat(buddy): open buddy companion feature to all users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.88",
+  "version": "2.1.89",
   "private": true,
   "description": "Restored Claude Code source tree reconstructed from source maps.",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/buddy/CompanionSprite.tsx
+++ b/src/buddy/CompanionSprite.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react/compiler-runtime";
-import { feature } from 'bun:bundle';
 import figures from 'figures';
 import React, { useEffect, useRef, useState } from 'react';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
@@ -165,7 +164,6 @@ function spriteColWidth(nameWidth: number): number {
 // Narrow terminals: 0 — REPL.tsx stacks the one-liner on its own row
 // (above input in fullscreen, below in scrollback), so no reservation.
 export function companionReservedColumns(terminalColumns: number, speaking: boolean): number {
-  if (!feature('BUDDY')) return 0;
   const companion = getCompanion();
   if (!companion || getGlobalConfig().companionMuted) return 0;
   if (terminalColumns < MIN_COLS_FOR_FULL_SPRITE) return 0;
@@ -212,7 +210,6 @@ export function CompanionSprite(): React.ReactNode {
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- tick intentionally captured at reaction-change, not tracked
   }, [reaction, setAppState]);
-  if (!feature('BUDDY')) return null;
   const companion = getCompanion();
   if (!companion || getGlobalConfig().companionMuted) return null;
   const color = RARITY_COLORS[companion.rarity];
@@ -337,7 +334,7 @@ export function CompanionFloatingBubble() {
     t3 = $[4];
   }
   useEffect(t2, t3);
-  if (!feature("BUDDY") || !reaction) {
+  if (!reaction) {
     return null;
   }
   const companion = getCompanion();

--- a/src/buddy/prompt.ts
+++ b/src/buddy/prompt.ts
@@ -1,4 +1,3 @@
-import { feature } from 'bun:bundle'
 import type { Message } from '../types/message.js'
 import type { Attachment } from '../utils/attachments.js'
 import { getGlobalConfig } from '../utils/config.js'
@@ -15,7 +14,6 @@ When the user addresses ${name} directly (by name), its bubble will answer. Your
 export function getCompanionIntroAttachment(
   messages: Message[] | undefined,
 ): Attachment[] {
-  if (!feature('BUDDY')) return []
   const companion = getCompanion()
   if (!companion || getGlobalConfig().companionMuted) return []
 

--- a/src/buddy/useBuddyNotification.tsx
+++ b/src/buddy/useBuddyNotification.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react/compiler-runtime";
-import { feature } from 'bun:bundle';
 import React, { useEffect } from 'react';
 import { useNotifications } from '../context/notifications.js';
 import { Text } from '../ink.js';
@@ -50,9 +49,6 @@ export function useBuddyNotification() {
   let t1;
   if ($[0] !== addNotification || $[1] !== removeNotification) {
     t0 = () => {
-      if (!feature("BUDDY")) {
-        return;
-      }
       const config = getGlobalConfig();
       if (config.companion || !isBuddyTeaserWindow()) {
         return;
@@ -80,7 +76,6 @@ export function findBuddyTriggerPositions(text: string): Array<{
   start: number;
   end: number;
 }> {
-  if (!feature('BUDDY')) return [];
   const triggers: Array<{
     start: number;
     end: number;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -115,12 +115,8 @@ const forkCmd = feature('FORK_SUBAGENT')
       require('./commands/fork/index.js') as typeof import('./commands/fork/index.js')
     ).default
   : null
-const buddy = feature('BUDDY')
-  ? (
-      require('./commands/buddy/index.js') as typeof import('./commands/buddy/index.js')
-    ).default
-  : null
 /* eslint-enable @typescript-eslint/no-require-imports */
+import buddy from './commands/buddy/index.js'
 import thinkback from './commands/thinkback/index.js'
 import thinkbackPlay from './commands/thinkback-play/index.js'
 import permissions from './commands/permissions/index.js'
@@ -319,7 +315,7 @@ const COMMANDS = memoize((): Command[] => [
   vim,
   ...(webCmd ? [webCmd] : []),
   ...(forkCmd ? [forkCmd] : []),
-  ...(buddy ? [buddy] : []),
+  buddy,
   ...(proactive ? [proactive] : []),
   ...(briefCommand ? [briefCommand] : []),
   ...(assistantCommand ? [assistantCommand] : []),

--- a/src/commands/buddy/buddy.tsx
+++ b/src/commands/buddy/buddy.tsx
@@ -1,0 +1,247 @@
+import * as React from 'react'
+import { Box, Text, useInput } from '../../ink.js'
+import { useSetAppState } from '../../state/AppState.js'
+import { getGlobalConfig, saveGlobalConfig } from '../../utils/config.js'
+import type { LocalJSXCommandCall } from '../../types/command.js'
+import {
+  getCompanion,
+  companionUserId,
+  roll,
+} from '../../buddy/companion.js'
+import { renderSprite } from '../../buddy/sprites.js'
+import {
+  RARITY_COLORS,
+  RARITY_STARS,
+  STAT_NAMES,
+  type Companion,
+} from '../../buddy/types.js'
+
+// ── Card ──────────────────────────────────────────────────────────────
+
+const CARD_WIDTH = 44
+
+function StatBar({
+  name,
+  value,
+  color,
+}: {
+  name: string
+  value: number
+  color: string
+}): React.ReactNode {
+  const filled = Math.round(value / 5)
+  const empty = 20 - filled
+  return (
+    <Text>
+      <Text dimColor>{name.padEnd(10)}</Text>
+      <Text color={color}>{'█'.repeat(filled)}</Text>
+      <Text dimColor>{'░'.repeat(empty)}</Text>
+      <Text> {value}</Text>
+    </Text>
+  )
+}
+
+function CompanionCard({
+  companion,
+  onDone,
+}: {
+  companion: Companion
+  onDone: () => void
+}): React.ReactNode {
+  const color = RARITY_COLORS[companion.rarity]
+  const sprite = renderSprite(companion)
+  const stars = RARITY_STARS[companion.rarity]
+
+  useInput((_input, key) => {
+    if (key.escape || key.return) {
+      onDone()
+    }
+  })
+
+  const shinyTag = companion.shiny ? ' [SHINY]' : ''
+  const title = ` ${companion.name} `
+  const subtitle = `${companion.species}${shinyTag}`
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={color}
+      paddingX={2}
+      paddingY={1}
+      width={CARD_WIDTH}
+    >
+      {/* Header */}
+      <Box justifyContent="center">
+        <Text bold color={color}>
+          {title}
+        </Text>
+      </Box>
+      <Box justifyContent="center">
+        <Text color={color}>{stars}</Text>
+        <Text dimColor> {companion.rarity}{shinyTag}</Text>
+      </Box>
+
+      {/* Sprite */}
+      <Box flexDirection="column" alignItems="center" marginTop={1}>
+        {sprite.map((line, i) => (
+          <Text key={i} color={color}>
+            {line}
+          </Text>
+        ))}
+      </Box>
+
+      {/* Species + personality */}
+      <Box flexDirection="column" alignItems="center" marginTop={1}>
+        <Text dimColor>{subtitle}</Text>
+        <Text dimColor italic>"{companion.personality}"</Text>
+      </Box>
+
+      {/* Stats */}
+      <Box
+        flexDirection="column"
+        marginTop={1}
+        borderStyle="single"
+        borderColor={color}
+        borderLeft={false}
+        borderRight={false}
+        borderBottom={false}
+        paddingTop={1}
+      >
+        {STAT_NAMES.map(stat => (
+          <StatBar
+            key={stat}
+            name={stat}
+            value={companion.stats[stat]}
+            color={color}
+          />
+        ))}
+      </Box>
+
+      {/* Footer hint */}
+      <Box justifyContent="center" marginTop={1}>
+        <Text dimColor>Press Esc or Enter to close</Text>
+      </Box>
+    </Box>
+  )
+}
+
+// ── Hatch ─────────────────────────────────────────────────────────────
+
+function HatchScreen({
+  onDone,
+}: {
+  onDone: (result?: string) => void
+}): React.ReactNode {
+  const [companion, setCompanion] = React.useState<Companion | null>(null)
+
+  React.useEffect(() => {
+    const existing = getCompanion()
+    if (existing) {
+      setCompanion(existing)
+      return
+    }
+
+    const userId = companionUserId()
+    const { bones, inspirationSeed } = roll(userId)
+
+    const names = [
+      'Pip', 'Nox', 'Fizz', 'Boop', 'Wren', 'Tink', 'Mochi', 'Zeph',
+      'Cosmo', 'Nimbus', 'Pixel', 'Sprout', 'Ember', 'Clover', 'Luna',
+      'Ziggy', 'Pebble', 'Maple', 'Rusty', 'Misty',
+    ]
+    const name = names[inspirationSeed % names.length]!
+    const personalities = [
+      'cheerful and curious',
+      'quietly observant',
+      'mischievously playful',
+      'wise beyond their years',
+      'endlessly optimistic',
+      'calm and collected',
+      'energetic and bouncy',
+      'thoughtful and kind',
+    ]
+    const personality =
+      personalities[(inspirationSeed >> 4) % personalities.length]!
+
+    const soul = { name, personality, hatchedAt: Date.now() }
+    saveGlobalConfig(config => ({ ...config, companion: soul }))
+
+    const fullCompanion: Companion = { ...bones, ...soul }
+    setCompanion(fullCompanion)
+  }, [])
+
+  if (!companion) {
+    return <Text>Hatching...</Text>
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color={RARITY_COLORS[companion.rarity]}>
+        Your companion hatched!
+      </Text>
+      <CompanionCard companion={companion} onDone={() => onDone()} />
+    </Box>
+  )
+}
+
+// ── Main command ──────────────────────────────────────────────────────
+
+export const call: LocalJSXCommandCall = async (onDone, _context, args) => {
+  const sub = args.trim().toLowerCase()
+
+  if (sub === 'pet') {
+    const companion = getCompanion()
+    if (!companion) {
+      onDone('No companion yet — try /buddy hatch first!')
+      return null
+    }
+    const PetAction = (): React.ReactNode => {
+      const setAppState = useSetAppState()
+      React.useEffect(() => {
+        setAppState(prev => ({ ...prev, companionPetAt: Date.now() }))
+        onDone(`You pet ${companion.name}!`)
+      }, [setAppState])
+      return null
+    }
+    return <PetAction />
+  }
+
+  if (sub === 'card') {
+    const companion = getCompanion()
+    if (!companion) {
+      onDone('No companion yet — try /buddy hatch first!')
+      return null
+    }
+    return <CompanionCard companion={companion} onDone={() => onDone()} />
+  }
+
+  if (sub === 'mute') {
+    saveGlobalConfig(config => ({ ...config, companionMuted: true }))
+    onDone('Companion muted. Use /buddy unmute to bring them back.')
+    return null
+  }
+
+  if (sub === 'unmute') {
+    saveGlobalConfig(config => ({ ...config, companionMuted: false }))
+    onDone('Companion unmuted!')
+    return null
+  }
+
+  if (sub === 'hatch' || sub === '') {
+    const existing = getCompanion()
+    if (existing && sub === '') {
+      return <CompanionCard companion={existing} onDone={() => onDone()} />
+    }
+    if (existing && sub === 'hatch') {
+      onDone(`You already have a companion: ${existing.name}!`)
+      return null
+    }
+    return <HatchScreen onDone={onDone} />
+  }
+
+  onDone(
+    `Unknown subcommand: ${sub}. Try: /buddy, /buddy hatch, /buddy pet, /buddy card, /buddy mute, /buddy unmute`,
+  )
+  return null
+}

--- a/src/commands/buddy/index.ts
+++ b/src/commands/buddy/index.ts
@@ -1,0 +1,11 @@
+import type { Command } from '../../commands.js'
+
+const buddy = {
+  type: 'local-jsx',
+  name: 'buddy',
+  description: 'Hatch, pet, and interact with your AI companion',
+  argumentHint: '[hatch | pet | card | mute | unmute]',
+  load: () => import('./buddy.js'),
+} satisfies Command
+
+export default buddy

--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -309,10 +309,7 @@ function PromptInput({
   const {
     companion: _companion,
     companionMuted
-  } = feature('BUDDY') ? getGlobalConfig() : {
-    companion: undefined,
-    companionMuted: undefined
-  };
+  } = getGlobalConfig();
   const companionFooterVisible = !!_companion && !companionMuted;
   // Brief mode: BriefSpinner/BriefIdleStatus own the 2-row footprint above
   // the input. Dropping marginTop here lets the spinner sit flush against
@@ -1786,10 +1783,8 @@ function PromptInput({
       }
       switch (footerItemSelected) {
         case 'companion':
-          if (feature('BUDDY')) {
-            selectFooterItem(null);
-            void onSubmit('/buddy');
-          }
+          selectFooterItem(null);
+          void onSubmit('/buddy');
           break;
         case 'tasks':
           if (isTeammateMode) {
@@ -1981,9 +1976,7 @@ function PromptInput({
     });
   }, [effortNotificationText, addNotification, removeNotification]);
   useBuddyNotification();
-  const companionSpeaking = feature('BUDDY') ?
-  // biome-ignore lint/correctness/useHookAtTopLevel: feature() is a compile-time constant
-  useAppState(s => s.companionReaction !== undefined) : false;
+  const companionSpeaking = useAppState(s => s.companionReaction !== undefined);
   const {
     columns,
     rows

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1331,12 +1331,10 @@ export function REPL({
       // Dismiss the companion bubble on scroll — it's absolute-positioned
       // at bottom-right and covers transcript content. Scrolling = user is
       // trying to read something under it.
-      if (feature('BUDDY')) {
-        setAppState(prev => prev.companionReaction === undefined ? prev : {
-          ...prev,
-          companionReaction: undefined
-        });
-      }
+      setAppState(prev => prev.companionReaction === undefined ? prev : {
+        ...prev,
+        companionReaction: undefined
+      });
     }
   }, [onRepin, onScrollAway, maybeLoadOlder, setAppState]);
   // Deferred SessionStart hook messages — REPL renders immediately and
@@ -2833,12 +2831,10 @@ export function REPL({
     })) {
       onQueryEvent(event);
     }
-    if (feature('BUDDY')) {
-      void fireCompanionObserver(messagesRef.current, reaction => setAppState(prev => prev.companionReaction === reaction ? prev : {
-        ...prev,
-        companionReaction: reaction
-      }));
-    }
+    void fireCompanionObserver(messagesRef.current, reaction => setAppState(prev => prev.companionReaction === reaction ? prev : {
+      ...prev,
+      companionReaction: reaction
+    }));
     queryCheckpoint('query_end');
 
     // Capture ant-only API metrics before resetLoadingState clears the ref.
@@ -4616,7 +4612,7 @@ export function REPL({
       {feature('MESSAGE_ACTIONS') && isFullscreenEnvEnabled() && !disableMessageActions ? <MessageActionsKeybindings handlers={messageActionHandlers} isActive={cursor !== null} /> : null}
       <CancelRequestHandler {...cancelRequestProps} />
       <MCPConnectionManager key={remountKey} dynamicMcpConfig={dynamicMcpConfig} isStrictMcpConfig={strictMcpConfig}>
-        <FullscreenLayout scrollRef={scrollRef} overlay={toolPermissionOverlay} bottomFloat={feature('BUDDY') && companionVisible && !companionNarrow ? <CompanionFloatingBubble /> : undefined} modal={centeredModal} modalScrollRef={modalScrollRef} dividerYRef={dividerYRef} hidePill={!!viewedAgentTask} hideSticky={!!viewedTeammateTask} newMessageCount={unseenDivider?.count ?? 0} onPillClick={() => {
+        <FullscreenLayout scrollRef={scrollRef} overlay={toolPermissionOverlay} bottomFloat={companionVisible && !companionNarrow ? <CompanionFloatingBubble /> : undefined} modal={centeredModal} modalScrollRef={modalScrollRef} dividerYRef={dividerYRef} hidePill={!!viewedAgentTask} hideSticky={!!viewedTeammateTask} newMessageCount={unseenDivider?.count ?? 0} onPillClick={() => {
         setCursor(null);
         jumpToNew(scrollRef.current);
       }} scrollable={<>
@@ -4641,8 +4637,8 @@ export function REPL({
               {showSpinner && <SpinnerWithVerb mode={streamMode} spinnerTip={spinnerTip} responseLengthRef={responseLengthRef} apiMetricsRef={apiMetricsRef} overrideMessage={spinnerMessage} spinnerSuffix={stopHookSpinnerSuffix} verbose={verbose} loadingStartTimeRef={loadingStartTimeRef} totalPausedMsRef={totalPausedMsRef} pauseStartTimeRef={pauseStartTimeRef} overrideColor={spinnerColor} overrideShimmerColor={spinnerShimmerColor} hasActiveTools={inProgressToolUseIDs.size > 0} leaderIsIdle={!isLoading} />}
               {!showSpinner && !isLoading && !userInputOnProcessing && !hasRunningTeammates && isBriefOnly && !viewedAgentTask && <BriefIdleStatus />}
               {isFullscreenEnvEnabled() && <PromptInputQueuedCommands />}
-            </>} bottom={<Box flexDirection={feature('BUDDY') && companionNarrow ? 'column' : 'row'} width="100%" alignItems={feature('BUDDY') && companionNarrow ? undefined : 'flex-end'}>
-              {feature('BUDDY') && companionNarrow && isFullscreenEnvEnabled() && companionVisible ? <CompanionSprite /> : null}
+            </>} bottom={<Box flexDirection={companionNarrow ? 'column' : 'row'} width="100%" alignItems={companionNarrow ? undefined : 'flex-end'}>
+              {companionNarrow && isFullscreenEnvEnabled() && companionVisible ? <CompanionSprite /> : null}
               <Box flexDirection="column" flexGrow={1}>
                 {permissionStickyFooter}
                 {/* Immediate local-jsx commands (/btw, /sandbox, /assistant,
@@ -5046,7 +5042,7 @@ export function REPL({
           }} />}
                 {"external" === 'ant' && <DevBar />}
               </Box>
-              {feature('BUDDY') && !(companionNarrow && isFullscreenEnvEnabled()) && companionVisible ? <CompanionSprite /> : null}
+              {!(companionNarrow && isFullscreenEnvEnabled()) && companionVisible ? <CompanionSprite /> : null}
             </Box>} />
       </MCPConnectionManager>
     </KeybindingSetup>;

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -861,13 +861,9 @@ export async function getAttachments(
         ),
       ),
     ),
-    ...(feature('BUDDY')
-      ? [
-          maybe('companion_intro', () =>
-            Promise.resolve(getCompanionIntroAttachment(messages)),
-          ),
-        ]
-      : []),
+    maybe('companion_intro', () =>
+      Promise.resolve(getCompanionIntroAttachment(messages)),
+    ),
     maybe('changed_files', () => getChangedFiles(context)),
     maybe('nested_memory', () => getNestedMemoryAttachments(context)),
     // relevant_memories moved to async prefetch (startRelevantMemoryPrefetch)


### PR DESCRIPTION
## Summary
- Remove all compile-time `feature('BUDDY')` gates, making the buddy companion available to all users unconditionally
- Create the missing `src/commands/buddy/` command module (`index.ts` + `buddy.tsx`) with subcommands: `hatch`, `pet`, `card`, `mute`, `unmute`
- Companion card renders inside an Ink rounded-border box and dismisses on Esc/Enter

## Test plan
- [x] Run `/buddy hatch` to verify a companion is generated and card is displayed
- [x] Run `/buddy` or `/buddy card` to verify the card UI renders with border, stats, and sprite
- [x] Press Esc or Enter on the card to verify it dismisses correctly
- [x] Run `/buddy pet` to verify heart animation triggers
- [x] Run `/buddy mute` / `/buddy unmute` to verify companion visibility toggle
- [x] Verify companion sprite appears in the terminal sidebar for all user types
- [x] Verify `/buddy` teaser notification shows during the teaser window (April 1-7)