### PR TITLE
feat(terminal-capture): remove feature flag and enable terminal panel for all users

### DIFF
--- a/src/components/PromptInput/PromptInputHelpMenu.tsx
+++ b/src/components/PromptInput/PromptInputHelpMenu.tsx
@@ -129,7 +129,7 @@ export function PromptInputHelpMenu(props) {
   const imagePasteShortcut = t19;
   let t20;
   if ($[20] !== dimColor || $[21] !== terminalShortcut) {
-    t20 = feature("TERMINAL_PANEL") ? getFeatureValue_CACHED_MAY_BE_STALE("tengu_terminal_panel", false) ? <Box><Text dimColor={dimColor}>{terminalShortcut} for terminal</Text></Box> : null : null;
+    t20 = <Box><Text dimColor={dimColor}>{terminalShortcut} for terminal</Text></Box>;
     $[20] = dimColor;
     $[21] = terminalShortcut;
     $[22] = t20;

--- a/src/hooks/useGlobalKeybindings.tsx
+++ b/src/hooks/useGlobalKeybindings.tsx
@@ -208,12 +208,7 @@ export function GlobalKeybindingHandlers({
   // Toggle built-in terminal panel (meta+j).
   // toggle() blocks in spawnSync until the user detaches from tmux.
   const handleToggleTerminal = useCallback(() => {
-    if (feature('TERMINAL_PANEL')) {
-      if (!getFeatureValue_CACHED_MAY_BE_STALE('tengu_terminal_panel', false)) {
-        return;
-      }
-      getTerminalPanel().toggle();
-    }
+    getTerminalPanel().toggle();
   }, []);
   useKeybinding('app:toggleTerminal', handleToggleTerminal, {
     context: 'Global'

--- a/src/keybindings/defaultBindings.ts
+++ b/src/keybindings/defaultBindings.ts
@@ -57,7 +57,7 @@ export const DEFAULT_BINDINGS: KeybindingBlock[] = [
             'cmd+shift+p': 'app:quickOpen' as const,
           }
         : {}),
-      ...(feature('TERMINAL_PANEL') ? { 'meta+j': 'app:toggleTerminal' } : {}),
+      'meta+j': 'app:toggleTerminal',
     },
   },
   {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -110,10 +110,9 @@ const OverflowTestTool = feature('OVERFLOW_TEST_TOOL')
 const CtxInspectTool = feature('CONTEXT_COLLAPSE')
   ? require('./tools/CtxInspectTool/CtxInspectTool.js').CtxInspectTool
   : null
-const TerminalCaptureTool = feature('TERMINAL_PANEL')
-  ? require('./tools/TerminalCaptureTool/TerminalCaptureTool.js')
-      .TerminalCaptureTool
-  : null
+const TerminalCaptureTool =
+  require('./tools/TerminalCaptureTool/TerminalCaptureTool.js')
+    .TerminalCaptureTool
 const WebBrowserTool = feature('WEB_BROWSER_TOOL')
   ? require('./tools/WebBrowserTool/WebBrowserTool.js').WebBrowserTool
   : null
@@ -220,7 +219,7 @@ export function getAllBaseTools(): Tools {
       : []),
     ...(OverflowTestTool ? [OverflowTestTool] : []),
     ...(CtxInspectTool ? [CtxInspectTool] : []),
-    ...(TerminalCaptureTool ? [TerminalCaptureTool] : []),
+    TerminalCaptureTool,
     ...(isEnvTruthy(process.env.ENABLE_LSP_TOOL) ? [LSPTool] : []),
     ...(isWorktreeModeEnabled() ? [EnterWorktreeTool, ExitWorktreeTool] : []),
     getSendMessageTool(),

--- a/src/tools/TerminalCaptureTool/TerminalCaptureTool.ts
+++ b/src/tools/TerminalCaptureTool/TerminalCaptureTool.ts
@@ -1,0 +1,124 @@
+import { spawnSync } from 'child_process'
+import { z } from 'zod/v4'
+import { buildTool, type ToolDef } from '../../Tool.js'
+import { lazySchema } from '../../utils/lazySchema.js'
+import { getTerminalPanelSocket } from '../../utils/terminalPanel.js'
+import {
+  DESCRIPTION,
+  PROMPT,
+  TERMINAL_CAPTURE_TOOL_NAME,
+} from './prompt.js'
+
+const TMUX_SESSION = 'panel'
+
+const inputSchema = lazySchema(() =>
+  z.strictObject({
+    lines: z
+      .number()
+      .int()
+      .min(1)
+      .max(10000)
+      .optional()
+      .describe(
+        'Number of scrollback lines to capture. Defaults to the visible pane height. ' +
+          'Use a larger value to see scrollback history.',
+      ),
+  }),
+)
+type InputSchema = ReturnType<typeof inputSchema>
+
+const outputSchema = lazySchema(() =>
+  z.object({
+    content: z.string().describe('The captured terminal content'),
+    lines: z.number().describe('Number of lines captured'),
+  }),
+)
+type OutputSchema = ReturnType<typeof outputSchema>
+type Output = z.infer<OutputSchema>
+
+function hasSession(): boolean {
+  const result = spawnSync(
+    'tmux',
+    ['-L', getTerminalPanelSocket(), 'has-session', '-t', TMUX_SESSION],
+    { encoding: 'utf-8' },
+  )
+  return result.status === 0
+}
+
+function capturePane(lines?: number): { content: string; lineCount: number } {
+  const socket = getTerminalPanelSocket()
+  const args = ['-L', socket, 'capture-pane', '-t', TMUX_SESSION, '-p']
+
+  if (lines !== undefined) {
+    // -S -N captures N lines of scrollback from the top of the history
+    args.push('-S', `-${lines}`)
+  }
+
+  const result = spawnSync('tmux', args, { encoding: 'utf-8' })
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to capture terminal panel: ${result.stderr?.trim() || 'unknown error'}`,
+    )
+  }
+
+  const content = result.stdout
+  // Trim trailing empty lines but preserve internal structure
+  const trimmed = content.replace(/\n+$/, '')
+  const lineCount = trimmed === '' ? 0 : trimmed.split('\n').length
+
+  return { content: trimmed, lineCount }
+}
+
+export const TerminalCaptureTool = buildTool({
+  name: TERMINAL_CAPTURE_TOOL_NAME,
+  searchHint: 'read the contents of the built-in terminal panel',
+  maxResultSizeChars: 100_000,
+  get inputSchema(): InputSchema {
+    return inputSchema()
+  },
+  get outputSchema(): OutputSchema {
+    return outputSchema()
+  },
+  isReadOnly() {
+    return true
+  },
+  isConcurrencySafe() {
+    return true
+  },
+  async description() {
+    return DESCRIPTION
+  },
+  async prompt() {
+    return PROMPT
+  },
+  async call(
+    input: z.infer<InputSchema>,
+  ): Promise<{ data: Output } | { error: string }> {
+    // Check if the terminal panel tmux session exists
+    if (!hasSession()) {
+      return {
+        error:
+          'Terminal panel is not active. The user has not opened the terminal panel yet ' +
+          '(Alt+J), or tmux is not available on this system.',
+      }
+    }
+
+    try {
+      const { content, lineCount } = capturePane(input.lines)
+
+      if (lineCount === 0) {
+        return { data: { content: '(terminal is empty)', lines: 0 } }
+      }
+
+      return { data: { content, lines: lineCount } }
+    } catch (err) {
+      return {
+        error:
+          err instanceof Error
+            ? err.message
+            : 'Failed to capture terminal panel content',
+      }
+    }
+  },
+} satisfies ToolDef<InputSchema, Output>)

--- a/src/tools/TerminalCaptureTool/prompt.ts
+++ b/src/tools/TerminalCaptureTool/prompt.ts
@@ -1,1 +1,15 @@
 export const TERMINAL_CAPTURE_TOOL_NAME = 'terminal_capture'
+
+export const DESCRIPTION =
+  'Capture the current visible content of the built-in terminal panel (Alt+J). ' +
+  'Returns the text currently displayed in the terminal pane. ' +
+  'Use this when you need to see what the user is looking at in their terminal panel — ' +
+  'for example, to read command output, error messages, or logs from a running process.'
+
+export const PROMPT =
+  'Use this tool to read the contents of the built-in terminal panel. ' +
+  'The terminal panel is a persistent shell session the user can toggle with Alt+J. ' +
+  'This tool captures the visible text from that terminal. ' +
+  'Use the `lines` parameter to control how many lines of scrollback history to capture. ' +
+  'If the terminal panel has not been opened yet or tmux is not available, ' +
+  'the tool will return an error explaining the situation.'

--- a/src/utils/permissions/classifierDecision.ts
+++ b/src/utils/permissions/classifierDecision.ts
@@ -24,11 +24,8 @@ import { YOLO_CLASSIFIER_TOOL_NAME } from './yoloClassifier.js'
 // Ant-only tool names: conditional require so Bun can DCE these in external builds.
 // Gates mirror tools.ts. Keeps the tool name strings out of cli.js.
 /* eslint-disable @typescript-eslint/no-require-imports */
-const TERMINAL_CAPTURE_TOOL_NAME = feature('TERMINAL_PANEL')
-  ? (
-      require('../../tools/TerminalCaptureTool/prompt.js') as typeof import('../../tools/TerminalCaptureTool/prompt.js')
-    ).TERMINAL_CAPTURE_TOOL_NAME
-  : null
+const { TERMINAL_CAPTURE_TOOL_NAME } =
+  require('../../tools/TerminalCaptureTool/prompt.js') as typeof import('../../tools/TerminalCaptureTool/prompt.js')
 const OVERFLOW_TEST_TOOL_NAME = feature('OVERFLOW_TEST_TOOL')
   ? (
       require('../../tools/OverflowTestTool/OverflowTestTool.js') as typeof import('../../tools/OverflowTestTool/OverflowTestTool.js')
@@ -86,7 +83,7 @@ const SAFE_YOLO_ALLOWLISTED_TOOLS = new Set([
   // Misc safe
   SLEEP_TOOL_NAME,
   // Ant-only safe tools (gates mirror tools.ts)
-  ...(TERMINAL_CAPTURE_TOOL_NAME ? [TERMINAL_CAPTURE_TOOL_NAME] : []),
+  TERMINAL_CAPTURE_TOOL_NAME,
   ...(OVERFLOW_TEST_TOOL_NAME ? [OVERFLOW_TEST_TOOL_NAME] : []),
   ...(VERIFY_PLAN_EXECUTION_TOOL_NAME ? [VERIFY_PLAN_EXECUTION_TOOL_NAME] : []),
   // Internal classifier tool


### PR DESCRIPTION
## Summary
- Remove `TERMINAL_PANEL` feature flag gating from terminal capture tool, keybindings, help menu, and permission classifier
- Add description and prompt constants for the `TerminalCaptureTool`
- Terminal panel (Alt+J) is now available to all users without feature flag checks

## Test plan
- [x] Verify terminal panel toggles with Alt+J
- [x] Verify `terminal_capture` tool works in conversations
- [x] Verify help menu shows terminal shortcut