### PR TITLE
feat(compaction-reminders): remove feature flag and enable for all users

### DIFF
--- a/docs/changelogs/v2.1.89.md
+++ b/docs/changelogs/v2.1.89.md
@@ -41,3 +41,7 @@
 - 支持标准 skill frontmatter（name、description、when-to-use 等）
 - MCP skills 出现在可用 skills 列表中，可被模型自动调用
 - 安全限制：MCP skills 中的 inline shell 命令不会被执行
+
+## compaction-reminders
+
+开启压缩提醒功能，在上下文压缩后向模型附加提醒信息，帮助 Claude 在压缩后保持对关键上下文的感知。

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -915,18 +915,14 @@ export async function getAttachments(
     maybe('critical_system_reminder', () =>
       Promise.resolve(getCriticalSystemReminderAttachment(toolUseContext)),
     ),
-    ...(feature('COMPACTION_REMINDERS')
-      ? [
-          maybe('compaction_reminder', () =>
-            Promise.resolve(
-              getCompactionReminderAttachment(
-                messages ?? [],
-                toolUseContext.options.mainLoopModel,
-              ),
-            ),
-          ),
-        ]
-      : []),
+    maybe('compaction_reminder', () =>
+      Promise.resolve(
+        getCompactionReminderAttachment(
+          messages ?? [],
+          toolUseContext.options.mainLoopModel,
+        ),
+      ),
+    ),
     ...(feature('HISTORY_SNIP')
       ? [
           maybe('context_efficiency', () =>


### PR DESCRIPTION
## Summary
- Remove `COMPACTION_REMINDERS` feature flag guard from `src/utils/attachments.ts`, enabling compaction reminder attachment for all users
- Add compaction-reminders changelog entry to `docs/changelogs/v2.1.89.md`

Closes #30

## Test plan
- [x] `grep -rn "COMPACTION_REMINDERS"` confirms no remaining feature flag references
- [x] Trigger auto-compact in a long conversation and verify compaction reminder attachment is included