### PR TITLE
feat(slow-ops): enable slow operation logging for all users

### DIFF
--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -1567,7 +1567,6 @@ const MAX_SLOW_OPERATIONS = 10
 const SLOW_OPERATION_TTL_MS = 10000
 
 export function addSlowOperation(operation: string, durationMs: number): void {
-  if (process.env.USER_TYPE !== 'ant') return
   // Skip tracking for editor sessions (user editing a prompt file in $EDITOR)
   // These are intentionally slow since the user is drafting text
   if (operation.includes('exec') && operation.includes('claude-prompt-')) {

--- a/src/utils/slowOperations.ts
+++ b/src/utils/slowOperations.ts
@@ -1,4 +1,3 @@
-import { feature } from 'bun:bundle'
 import type { WriteFileOptions } from 'fs'
 import {
   closeSync,
@@ -24,7 +23,7 @@ type WriteFileOptionsWithFlush =
  * Operations taking longer than this will be logged for debugging.
  * - Override: set CLAUDE_CODE_SLOW_OPERATION_THRESHOLD_MS to a number
  * - Dev builds: 20ms (lower threshold for development)
- * - Ants: 300ms (enabled for all internal users)
+ * - Default: 300ms
  */
 const SLOW_OPERATION_THRESHOLD_MS = (() => {
   const envValue = process.env.CLAUDE_CODE_SLOW_OPERATION_THRESHOLD_MS
@@ -37,10 +36,7 @@ const SLOW_OPERATION_THRESHOLD_MS = (() => {
   if (process.env.NODE_ENV === 'development') {
     return 20
   }
-  if (process.env.USER_TYPE === 'ant') {
-    return 300
-  }
-  return Infinity
+  return 300
 })()
 
 // Re-export for callers that still need the threshold value directly
@@ -142,11 +138,8 @@ function slowLoggingExternal(): Disposable {
 /**
  * Tagged template for slow operation logging.
  *
- * In ANT builds: creates an AntSlowLogger that times the operation and logs
+ * Creates an AntSlowLogger that times the operation and logs
  * if it exceeds the threshold. Description is built lazily only when slow.
- *
- * In external builds: returns a singleton no-op disposable. Zero allocations,
- * zero timing. AntSlowLogger and buildDescription are dead-code-eliminated.
  *
  * @example
  * using _ = slowLogging`structuredClone(${value})`
@@ -154,7 +147,7 @@ function slowLoggingExternal(): Disposable {
  */
 export const slowLogging: {
   (strings: TemplateStringsArray, ...values: unknown[]): Disposable
-} = feature('SLOW_OPERATION_LOGGING') ? slowLoggingAnt : slowLoggingExternal
+} = slowLoggingAnt
 
 // --- Wrapped operations ---
 


### PR DESCRIPTION
## Summary
- Remove `feature('SLOW_OPERATION_LOGGING')` compile-time gate — `slowLogging` now always uses the active `AntSlowLogger` implementation
- Remove `USER_TYPE=ant` → 300ms threshold condition — default threshold is now 300ms for all users (was `Infinity` for non-ant)
- Remove `USER_TYPE !== 'ant'` early return in `addSlowOperation()` so DevBar tracks slow ops for all users

## Test plan
- [x] `bun run ./src/dev-entry.ts --version` passes
- [x] Verify slow operations appear in debug log when an operation exceeds 300ms
- [x] Verify `CLAUDE_CODE_SLOW_OPERATION_THRESHOLD_MS` env var override still works

Closes #19