### PR TITLE
docs(contributing): update branch strategy from version/{version-id} to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@
 ## 工作流程
 
 1. **Fork** 本仓库并 clone 到本地
-2. 基于 `version/{version-id}` 分支创建你的功能分支
+2. 基于 `main` 分支创建你的功能分支
 3. 在本地完成开发与测试
 4. 确保所有提交符合下方的 **Conventional Commit 规范**
-5. 提交 **Pull Request** 到 `version/{version-id}` 分支
+5. 提交 **Pull Request** 到 `main` 分支
 6. 等待 Code Review，根据反馈修改后合并
 
 ## 环境准备


### PR DESCRIPTION
## Summary
- 更新 CONTRIBUTING.md 工作流程中的分支策略，将基准分支和 PR 目标分支从 `version/{version-id}` 改为 `main`，以反映当前实际的分支策略

Closes #76

## Test plan
- [x] 确认 CONTRIBUTING.md 中不再包含 `version/{version-id}` 引用
- [x] 确认工作流程步骤 2 和 5 均已更新为 `main`